### PR TITLE
Tell me that there's a problem when failing to re-register, instead o…

### DIFF
--- a/MCLauncher/MainWindow.xaml.cs
+++ b/MCLauncher/MainWindow.xaml.cs
@@ -109,8 +109,13 @@ namespace MCLauncher {
                 Debug.WriteLine("Deployment progress: " + p.state + " " + p.percentage + "%");
             };
             t.Completed += (v, p) => {
-                Debug.WriteLine("Deployment done: " + p);
-                src.SetResult(1);
+                if (p == AsyncStatus.Error) {
+                    Debug.WriteLine("Deployment failed: " + v.GetResults().ErrorText);
+                    src.SetException(new Exception("Deployment failed: " + v.GetResults().ErrorText));
+                } else {
+                    Debug.WriteLine("Deployment done: " + p);
+                    src.SetResult(1);
+                }
             };
             await src.Task;
         }


### PR DESCRIPTION
…f quietly failing to do anything

The culprit in my case was not enabling development mode on my machine, which made the launch silently fail with no errors. With this change, an error like the following will be produced when re-registering fails for some reason:
![image](https://user-images.githubusercontent.com/14214667/81691319-85bad880-9454-11ea-8c36-18e5010e9518.png)
