### PR TITLE
Fix build order when doing full solution build

### DIFF
--- a/MCLauncher.sln
+++ b/MCLauncher.sln
@@ -4,6 +4,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 15.0.28307.489
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MCLauncher", "MCLauncher\MCLauncher.csproj", "{9FEBCF6C-14EF-49E9-B57D-FCBC3BA4BC77}"
+	ProjectSection(ProjectDependencies) = postProject
+		{B7336BA7-1E83-43D8-BD0E-3D44C6E3D4E7} = {B7336BA7-1E83-43D8-BD0E-3D44C6E3D4E7}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WUTokenHelper", "WUTokenHelper\WUTokenHelper.vcxproj", "{B7336BA7-1E83-43D8-BD0E-3D44C6E3D4E7}"
 EndProject


### PR DESCRIPTION
MCLauncher fails to build when WUTokenHelper hasn't been build yet, so this PR makes the MCLauncher project depend on WUTokenHelper so that WUTokenHelper gets built first.