### PR TITLE
Add support for multiple system accounts

### DIFF
--- a/WUTokenHelper/WUTokenHelper.vcxproj
+++ b/WUTokenHelper/WUTokenHelper.vcxproj
@@ -95,6 +95,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="main.h" />
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>

--- a/WUTokenHelper/WUTokenHelper.vcxproj.filters
+++ b/WUTokenHelper/WUTokenHelper.vcxproj.filters
@@ -18,6 +18,9 @@
     <ClInclude Include="pch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="main.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/WUTokenHelper/main.h
+++ b/WUTokenHelper/main.h
@@ -1,0 +1,1 @@
+void GetRawToken(winrt::Windows::Security::Credentials::WebAccount& accountInfo, winrt::hstring& tokenBase64);


### PR DESCRIPTION
Fix issues when you have more than 1 account on a machine. This now loops all known accounts if the previous doesn't have access to download Minecraft.

I have attached the updated exe and dll below
[MCLauncher.zip](https://github.com/MCMrARM/mc-w10-version-launcher/files/5555742/MCLauncher.zip)

