### PR TITLE
add versions list available in China

### DIFF
--- a/.github/workflows/Sync version file to gitee.yml
+++ b/.github/workflows/Sync version file to gitee.yml
@@ -1,0 +1,21 @@
+name: Sync version.txt to gitee
+
+on:
+  schedule:
+    - cron: "0 7 * * 0"
+
+jobs:
+  run:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+    - name: Mirror Github to Gitee
+      uses: Yikun/hub-mirror-action@master
+      with:
+        src: github/MCMrARM
+        dst: gitee/quizhizhe
+        dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
+        dst_token:  ${{ secrets.GITEE_TOKEN }}
+        static_list: 'mc-w10-versiondb'
+        force_update: true
+        debug: true

--- a/MCLauncher/MainWindow.xaml.cs
+++ b/MCLauncher/MainWindow.xaml.cs
@@ -26,7 +26,7 @@ namespace MCLauncher {
 
         private static readonly string PREFS_PATH = @"preferences.json";
         private static readonly string IMPORTED_VERSIONS_PATH = @"imported_versions";
-        private static readonly string VERSIONS_API = "https://mrarm.io/r/w10-vdb";
+        private static readonly string[] VERSIONS_API = { "https://mrarm.io/r/w10-vdb", "https://gitee.com/quizhizhe/mc-w10-versiondb/raw/master/versions.json.min" };
 
         private VersionList _versions;
         public Preferences UserPrefs { get; }
@@ -38,9 +38,15 @@ namespace MCLauncher {
         private readonly Task _userVersionDownloaderLoginTask;
         private volatile int _userVersionDownloaderLoginTaskStarted;
         private volatile bool _hasLaunchTask = false;
+        private volatile int _realVersionAPI = 0;
 
         public MainWindow() {
-            _versions = new VersionList("versions.json", IMPORTED_VERSIONS_PATH, VERSIONS_API, this, VersionEntryPropertyChanged);
+            if(System.Threading.Thread.CurrentThread.CurrentCulture.Name == "zh-CN")
+            {
+                _realVersionAPI = 1; //Use Gitee mirror with China. 
+            }
+            
+            _versions = new VersionList("versions.json", IMPORTED_VERSIONS_PATH, VERSIONS_API[_realVersionAPI], this, VersionEntryPropertyChanged);
             InitializeComponent();
             ShowInstalledVersionsOnlyCheckbox.DataContext = this;
 


### PR DESCRIPTION
For some reasons, some github URLs cannot be accessed in China. For users who use MCLauncher in China, most of them cannot update the version list automatically. So I take the language method of identifying the system to judge whether to use Gitee in China